### PR TITLE
Feature/add email parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 as build
+FROM docker.io/alpine:3.20 as build
 
 RUN apk --update --no-cache add openjdk21 maven
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Login and password are `admin`. Check `http://localhost:8080/admin/master/consol
 There are 5 fields to configure, except standard protocol mapper provider configuration.
 ### Remote url
 This is remote url to fetch json from, you can optionally use a placeholders to insert keycloak user id, user name and email. 
-- Placeholders will work as following: assume your remote urls is `http://localhost/user` so that `http://localhost/user/**uid**/**uname**/**email**` will be transformed to `http://localhost/user/063943d2-d7ed-4bca-812b-506518c38228/test/test@example.com` given that `063943d2-d7ed-4bca-812b-506518c38228` is keycloak user id, `test` is user name and `test@example.com` is the email.
+- Placeholders will work as following: assume your remote urls is `http://localhost/user` so that `http://localhost/user/**uid**/**uname**/**email**` will be transformed to `http://localhost/user/063943d2-d7ed-4bca-812b-506518c38228/test/test%40example.com` given that `063943d2-d7ed-4bca-812b-506518c38228` is keycloak user id, `test` is user name and `test@example.com` is the email.
 ### Json path
 Optional json path expression to transform your remote endpoint response data.
 Given that **Token Claim Name** is configured as `user_roles` and remote endpoint response is:

--- a/README.md
+++ b/README.md
@@ -81,3 +81,21 @@ Set of key value pairs which you can use to configure custom request headers, wh
 ## License
 This project is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
+## Development
+
+Use Docker Compose to build and run changes in a local test environment
+
+```docker compose build```
+
+```docker compose up```
+
+This launches a Keycloak server loaded up with the module installed, a Postgresql database and a mocked server which serves user roles.
+
+Login to Keycloak with `admin` as the username and password and select the `dev` realm. A test user (username: `test`, password: `test`) is preconfigured and the custom mapper is loaded into the `account` client. Visit `Client Scopes -> account-dedicated -> external_claims` to change the settings.
+
+Run the following to generate the JWT token loaded with the mocked claims
+
+```
+curl -X POST http://localhost:8080/realms/dev/protocol/openid-connect/token -H 'Content-Type: application/x-www-form-urlencoded' -d grant_type=password -d client_id=account -d username=test -d password=test
+```
+

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Login and password are `admin`. Check `http://localhost:8080/admin/master/consol
 ## Configuration
 There are 5 fields to configure, except standard protocol mapper provider configuration.
 ### Remote url
-This is remote url to fetch json from, you can optionally use a placeholders to insert keycloak user id and user name. 
-- Placeholders will work as following: assume your remote urls is `http://localhost/user` so that `http://localhost/user/**uid**/**uname**` will be transformed to `http://localhost/user/063943d2-d7ed-4bca-812b-506518c38228/test` given that `063943d2-d7ed-4bca-812b-506518c38228` is keycloak user id and `test` is user name.
+This is remote url to fetch json from, you can optionally use a placeholders to insert keycloak user id, user name and email. 
+- Placeholders will work as following: assume your remote urls is `http://localhost/user` so that `http://localhost/user/**uid**/**uname**/**email**` will be transformed to `http://localhost/user/063943d2-d7ed-4bca-812b-506518c38228/test/test@example.com` given that `063943d2-d7ed-4bca-812b-506518c38228` is keycloak user id, `test` is user name and `test@example.com` is the email.
 ### Json path
 Optional json path expression to transform your remote endpoint response data.
 Given that **Token Claim Name** is configured as `user_roles` and remote endpoint response is:

--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ Run the following to generate the JWT token loaded with the mocked claims
 curl -X POST http://localhost:8080/realms/dev/protocol/openid-connect/token -H 'Content-Type: application/x-www-form-urlencoded' -d grant_type=password -d client_id=account -d username=test -d password=test
 ```
 
+The resulting `access_token` can then be inspected at [jwt.io](https://https://jwt.io/)

--- a/external-claim-mapper/src/main/java/org/zloom/ExternalClaimMapper.java
+++ b/external-claim-mapper/src/main/java/org/zloom/ExternalClaimMapper.java
@@ -33,6 +33,7 @@ import java.util.Map;
 public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
     private static final String USER_ID_PLACEHOLDER = "**uid**";
     private static final String USER_NAME_PLACEHOLDER = "**uname**";
+    private static final String USER_EMAIL_PLACEHOLDER = "**email**";
     private static final Logger LOGGER = Logger.getLogger(ExternalClaimMapper.class);
     private static final String REMOTE_URL_PROPERTY = "remoteUrl";
     private static final String JSON_PATH_EXPRESSION_PROPERTY = "jsonPath";
@@ -50,7 +51,7 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
                 .name(REMOTE_URL_PROPERTY)
                 .type(ProviderConfigProperty.STRING_TYPE)
                 .label("Remote url")
-                .helpText(String.format("Remote url to get claim for the given user, use %s and %s lowercase as placeholders", USER_ID_PLACEHOLDER, USER_NAME_PLACEHOLDER))
+                .helpText(String.format("Remote url to get claim for the given user, use %s, %s and %s lowercase as placeholders", USER_ID_PLACEHOLDER, USER_NAME_PLACEHOLDER, USER_EMAIL_PLACEHOLDER))
                 .add();
 
         propertiesBuilder
@@ -84,7 +85,7 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
                 .name(REQUEST_HEADERS_PROPERTY)
                 .type(ProviderConfigProperty.MAP_TYPE)
                 .label("Request headers")
-                .helpText(String.format("Configure headers attached to claim data request, use %s and %s lowercase as placeholders", USER_ID_PLACEHOLDER, USER_NAME_PLACEHOLDER))
+                .helpText(String.format("Configure headers attached to claim data request, use %s, %s and %s lowercase as placeholders", USER_ID_PLACEHOLDER, USER_NAME_PLACEHOLDER, USER_EMAIL_PLACEHOLDER))
                 .add();
 
         PROPERTIES_CONFIG = propertiesBuilder.build();
@@ -140,12 +141,13 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
     protected void setClaim(IDToken token, ProtocolMapperModel model, UserSessionModel user, KeycloakSession session, ClientSessionContext clientSessionCtx) {
         var uid = user.getUser().getId();
         var uname = user.getUser().getUsername();
-        var url = makeUrl(model, uid, uname);
+        var email = user.getUser().getEmail();
+        var url = makeUrl(model, uid, uname, email);
         if (url == null) {
             return;
         }
 
-        var claimData = getClaimData(model, token, url, uid, uname, session);
+        var claimData = getClaimData(model, token, url, uid, uname, email, session);
         if (IsEmpty(claimData)) {
             return;
         }
@@ -164,7 +166,7 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
         }
     }
 
-    private String makeUrl(ProtocolMapperModel mappingModel, String uid, String uname) {
+    private String makeUrl(ProtocolMapperModel mappingModel, String uid, String uname, String email) {
         var remoteUrl = mappingModel.getConfig().get(REMOTE_URL_PROPERTY);
         if (IsEmpty(remoteUrl)) {
             LOGGER.warn("Remote url is required");
@@ -172,7 +174,7 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
         }
 
         try {
-            var remoteUrlWithPlaceholders = remoteUrl.replace(USER_ID_PLACEHOLDER, uid).replace(USER_NAME_PLACEHOLDER, uname);
+            var remoteUrlWithPlaceholders = remoteUrl.replace(USER_ID_PLACEHOLDER, uid).replace(USER_NAME_PLACEHOLDER, uname).replace(USER_EMAIL_PLACEHOLDER, email);
             return new URL(remoteUrlWithPlaceholders).toString();
         } catch (MalformedURLException e) {
             LOGGER.errorv(e, "Could not create request url");
@@ -206,7 +208,7 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
         return request.auth(encodedIdToken);
     }
 
-    private SimpleHttp setHeaders(ProtocolMapperModel model, SimpleHttp request, String uid, String uname) {
+    private SimpleHttp setHeaders(ProtocolMapperModel model, SimpleHttp request, String uid, String uname, String email) {
         var mapperModel = new IdentityProviderMapperModel();
         mapperModel.setConfig(model.getConfig());
         var headers = mapperModel.getConfigMap(REQUEST_HEADERS_PROPERTY);
@@ -216,18 +218,18 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
 
         for (var header : headers.entrySet()) {
             var value = String.join(", ", header.getValue());
-            var valueWithPlaceholders = value.replace(USER_ID_PLACEHOLDER, uid).replace(USER_NAME_PLACEHOLDER, uname);
+            var valueWithPlaceholders = value.replace(USER_ID_PLACEHOLDER, uid).replace(USER_NAME_PLACEHOLDER, uname).replace(USER_EMAIL_PLACEHOLDER, email);
             request.header(header.getKey(), valueWithPlaceholders);
         }
 
         return request;
     }
 
-    private String getClaimData(ProtocolMapperModel model, IDToken token, String url, String uid, String uname, KeycloakSession session) {
+    private String getClaimData(ProtocolMapperModel model, IDToken token, String url, String uid, String uname, String email, KeycloakSession session) {
         try {
             LOGGER.infov("Getting claim data for user={0} from url={1}", uid, url);
             var request = SimpleHttp.doGet(url, session);
-            var response = setHeaders(model, setAuth(model, request, session, token), uid, uname).asResponse();
+            var response = setHeaders(model, setAuth(model, request, session, token), uid, uname, email).asResponse();
             var status = response.getStatus();
             var success = status >= 200 && status < 400;
             if (!success) {

--- a/external-claim-mapper/src/main/java/org/zloom/ExternalClaimMapper.java
+++ b/external-claim-mapper/src/main/java/org/zloom/ExternalClaimMapper.java
@@ -215,7 +215,12 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
     private SimpleHttp setHeaders(ProtocolMapperModel model, SimpleHttp request, String uid, String uname, String email) {
         var mapperModel = new IdentityProviderMapperModel();
         mapperModel.setConfig(model.getConfig());
-        var headers = mapperModel.getConfigMap(REQUEST_HEADERS_PROPERTY);
+        Map<String, List<String>> headers = null;
+        try {
+            headers = mapperModel.getConfigMap(REQUEST_HEADERS_PROPERTY);
+        } catch (RuntimeException e) {
+            LOGGER.infov("No headers configured, skipping");
+        }
         if (headers == null) {
             return request;
         }

--- a/external-claim-mapper/src/main/java/org/zloom/ExternalClaimMapper.java
+++ b/external-claim-mapper/src/main/java/org/zloom/ExternalClaimMapper.java
@@ -28,6 +28,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @AutoService(ProtocolMapper.class)
 public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
@@ -173,8 +175,10 @@ public class ExternalClaimMapper extends AbstractOIDCProtocolMapper implements O
             return null;
         }
 
+        var encodedEmail = IsEmpty(email) ? "" : URLEncoder.encode(email, StandardCharsets.UTF_8);
+
         try {
-            var remoteUrlWithPlaceholders = remoteUrl.replace(USER_ID_PLACEHOLDER, uid).replace(USER_NAME_PLACEHOLDER, uname).replace(USER_EMAIL_PLACEHOLDER, email);
+            var remoteUrlWithPlaceholders = remoteUrl.replace(USER_ID_PLACEHOLDER, uid).replace(USER_NAME_PLACEHOLDER, uname).replace(USER_EMAIL_PLACEHOLDER, encodedEmail);
             return new URL(remoteUrlWithPlaceholders).toString();
         } catch (MalformedURLException e) {
             LOGGER.errorv(e, "Could not create request url");

--- a/keycloak/import/dev-realm.json
+++ b/keycloak/import/dev-realm.json
@@ -389,6 +389,8 @@
       "consentRequired" : false,
       "config" : {
         "introspection.token.claim" : "true",
+        "requestHeaders" : "[ ]",
+        "userAuth" : "false",
         "userinfo.token.claim" : "true",
         "jsonPath" : "$.roles.values",
         "remoteUrl" : "http://mockserver:8081/userprofile",


### PR DESCRIPTION
Hi, this is a 'best guess' PR for the mapper to supply email as a parameter which would be really handy for my use case.

I don't have a Java build environment so admit I'm flying blind here but, looking at the docs for the Keycloak classes, it seems that `.getEmail()` would work and its a relatively small change.

I admit it hasn't been tested, or even compiled - please let me know if you would like me to work this up more